### PR TITLE
fix a dropped error in dispatch.iced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.1.11 (2016-03-03)
+
+Bugfixes:
+  * Fix a dropped error in Dispatch.
+
 ## v1.1.10 (2016-03-03)
 
 Features:

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -288,6 +288,8 @@
     Dispatch.prototype.unwrap_incoming_error = function(s) {
       if (typeof s === 'string') {
         return new Error(s);
+      } else {
+        return s;
       }
     };
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,1 @@
-exports.version = "1.1.9";
+exports.version = "1.1.11";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framed-msgpack-rpc",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Framed Msgpack RPC for node.js",
   "homepage": "https://github.com/maxtaco/node-framed-msgpack-rpc",
   "main": "./lib/main",

--- a/src/dispatch.iced
+++ b/src/dispatch.iced
@@ -189,7 +189,7 @@ exports.Dispatch = class Dispatch extends Packetizer
   get_hook_wrapper : () -> null
 
   wrap_outgoing_error   : (s) -> s.toString()
-  unwrap_incoming_error : (s) -> new Error(s) if typeof(s) is 'string'
+  unwrap_incoming_error : (s) -> if typeof(s) is 'string' then new Error(s) else s
 
   # please override me!
   get_handler_pair : (m) ->

--- a/src/version.iced
+++ b/src/version.iced
@@ -2,4 +2,4 @@
 # often wrong, but better than nothing...
 # ...this is overwritten in lib/version.js with the right
 # copy of the version (taken from package.json).
-exports.version = "1.0.16"
+exports.version = "1.1.11"


### PR DESCRIPTION
In commit f464c41 we factored out this line

```
error = new Error(error) if typeof(error) is 'string'
```

into this function

```
unwrap_incoming_error : (s) -> new Error(s) if typeof(s) is 'string'
...
error = @unwrap_incoming_error error
```

What looked like a simple refactor was actually a tricky bug, because of
CoffeScript's interpretation of `if`. In the original code, `if` guarded
the _entire statement_, meaning that `error` was not overwritten if it
was not a string. However in the new code, the assignment became
unconditional, and `error` was set to `undefined` if it was not a
string. This fix is to have `unwrap_incoming_error` return the original
error in that case.

r? @maxtaco 
