### PR TITLE
Fix encoding of compressed responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.20 (2020-03-10)
+
+ * Fix encoding bug for responses of compresses calls.
+
 ## v1.1.19 (2020-03-05)
 
  * implement `INVOKE_COMPRESSED` for parity with golang library's `CallCompressed`.

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -73,14 +73,14 @@
       if (this.debug_msg) {
         this.debug_msg.response(null, res).call();
       }
-      return this.dispatch.respond(this.seqid, this.ctype, null, res);
+      return this.dispatch.respond(this.seqid, null, res);
     };
 
     Response.prototype.error = function(err) {
       if (this.debug_msg) {
         this.debug_msg.response(err, null).call();
       }
-      return this.dispatch.respond(this.seqid, this.ctype, err, null);
+      return this.dispatch.respond(this.seqid, err, null);
     };
 
     return Response;
@@ -201,14 +201,9 @@
       }
     };
 
-    Dispatch.prototype.respond = function(seqid, ctype, error, result) {
+    Dispatch.prototype.respond = function(seqid, error, result) {
       var msg;
-      if (ctype != null) {
-        result = compress(ctype, result);
-        msg = [this.RESPONSE, seqid, ctype, error, result];
-      } else {
-        msg = [this.RESPONSE, seqid, error, result];
-      }
+      msg = [this.RESPONSE, seqid, error, result];
       return this.send(msg);
     };
 
@@ -270,7 +265,7 @@
                     return result = arguments[1];
                   };
                 })(),
-                lineno: 192
+                lineno: 188
               });
               __iced_deferrals._fulfill();
             })(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framed-msgpack-rpc",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Framed Msgpack RPC for node.js",
   "homepage": "https://github.com/keybase/node-framed-msgpack-rpc",
   "main": "./lib/main",

--- a/src/dispatch.iced
+++ b/src/dispatch.iced
@@ -46,11 +46,11 @@ exports.Response = class Response
   result : (res) ->
     res = compress @ctype, res
     @debug_msg.response(null, res).call() if @debug_msg
-    @dispatch.respond @seqid, @ctype, null, res
+    @dispatch.respond @seqid, null, res
 
   error : (err) ->
     @debug_msg.response(err, null).call() if @debug_msg
-    @dispatch.respond @seqid, @ctype, err, null
+    @dispatch.respond @seqid, err, null
 
 ##=======================================================================
 
@@ -136,12 +136,8 @@ exports.Dispatch = class Dispatch extends Packetizer
 
   ##-----------------------------------------
 
-  respond : (seqid, ctype, error, result) ->
-    if ctype?
-      result = compress ctype, result
-      msg = [ @RESPONSE, seqid, ctype, error, result ]
-    else
-      msg = [ @RESPONSE, seqid, error, result ]
+  respond : (seqid, error, result) ->
+    msg = [ @RESPONSE, seqid, error, result ]
     @send msg
 
   ##-----------------------------------------


### PR DESCRIPTION
Fixes two bugs from https://github.com/keybase/node-framed-msgpack-rpc/pull/11/ where 
1. we would double gzip responses
2. we would incorrectly add a `ctype` to the msg, the receiver has this information from the call so it's not needed and would otherwise break decoding.