### PR TITLE
Fix invoke uncompress

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -27,7 +27,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
             funcname: "Client.invoke"
           });
           _this.transport.invoke(arg, __iced_deferrals.defer({
@@ -63,7 +63,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
             funcname: "Client.invoke_compressed"
           });
           _this.transport.invoke(arg, __iced_deferrals.defer({

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -21,9 +21,9 @@
 
   iced = require('./iced').runtime;
 
-  COMPRESSION_TYPE_NONE = 0;
+  exports.COMPRESSION_TYPE_NONE = COMPRESSION_TYPE_NONE = 0;
 
-  COMPRESSION_TYPE_GZIP = 1;
+  exports.COMPRESSION_TYPE_GZIP = COMPRESSION_TYPE_GZIP = 1;
 
   compress = function(ctype, data) {
     if (ctype == null) {
@@ -257,7 +257,7 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/dispatch.iced",
+                filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/dispatch.iced",
                 funcname: "Dispatch.invoke"
               });
               _this._invocations[seqid] = __iced_deferrals.defer({
@@ -271,6 +271,9 @@
               });
               __iced_deferrals._fulfill();
             })(function() {
+              if ((ctype != null) && !error) {
+                result = uncompress(ctype, result);
+              }
               return __iced_k(debug_msg ? debug_msg.response(error, result).call() : void 0);
             });
           } else {

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -141,7 +141,7 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+                filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
                 funcname: "Listener.close"
               });
               _this._net_server.close(__iced_deferrals.defer({
@@ -215,7 +215,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
             funcname: "Listener.listen"
           });
           rv.wait(__iced_deferrals.defer({
@@ -266,7 +266,7 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+                  filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
                   funcname: "Listener.listen_retry"
                 });
                 _this.listen(__iced_deferrals.defer({
@@ -285,7 +285,7 @@
                     (function(__iced_k) {
                       __iced_deferrals = new iced.Deferrals(__iced_k, {
                         parent: ___iced_passed_deferral,
-                        filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+                        filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
                         funcname: "Listener.listen_retry"
                       });
                       setTimeout(__iced_deferrals.defer({

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -184,7 +184,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "Transport.connect"
           });
           _this._lock.acquire(__iced_deferrals.defer({
@@ -199,7 +199,7 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                  filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                   funcname: "Transport.connect"
                 });
                 _this._connect_critical_section(__iced_deferrals.defer({
@@ -396,7 +396,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "Transport._connect_critical_section"
           });
           rv.wait(__iced_deferrals.defer({
@@ -443,7 +443,7 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                      filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                       funcname: "Transport._connect_critical_section"
                     });
                     _this.hooks.after_connect(__iced_deferrals.defer({
@@ -526,7 +526,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "RobustTransport._connect_critical_section"
           });
           RobustTransport.__super__._connect_critical_section.call(_this, __iced_deferrals.defer({
@@ -562,7 +562,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "RobustTransport._connect_loop"
           });
           _this._lock.acquire(__iced_deferrals.defer({
@@ -599,7 +599,7 @@
                         (function(__iced_k) {
                           __iced_deferrals = new iced.Deferrals(__iced_k, {
                             parent: ___iced_passed_deferral,
-                            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                             funcname: "RobustTransport._connect_loop"
                           });
                           setTimeout(__iced_deferrals.defer({
@@ -613,7 +613,7 @@
                         (function(__iced_k) {
                           __iced_deferrals = new iced.Deferrals(__iced_k, {
                             parent: ___iced_passed_deferral,
-                            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                             funcname: "RobustTransport._connect_loop"
                           });
                           _this._connect_critical_section(__iced_deferrals.defer({
@@ -631,7 +631,7 @@
                               (function(__iced_k) {
                                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                                   parent: ___iced_passed_deferral,
-                                  filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                                  filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                                   funcname: "RobustTransport._connect_loop"
                                 });
                                 setTimeout(__iced_deferrals.defer({
@@ -698,7 +698,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "RobustTransport._timed_invoke"
           });
           rv.wait(__iced_deferrals.defer({
@@ -734,7 +734,7 @@
                     (function(__iced_k) {
                       __iced_deferrals = new iced.Deferrals(__iced_k, {
                         parent: ___iced_passed_deferral,
-                        filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                        filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                         funcname: "RobustTransport._timed_invoke"
                       });
                       rv.wait(__iced_deferrals.defer({

--- a/src/dispatch.iced
+++ b/src/dispatch.iced
@@ -7,8 +7,8 @@ toBuffer = require('typedarray-to-buffer')
 
 iced = require('./iced').runtime
 
-COMPRESSION_TYPE_NONE = 0
-COMPRESSION_TYPE_GZIP = 1
+exports.COMPRESSION_TYPE_NONE = COMPRESSION_TYPE_NONE = 0
+exports.COMPRESSION_TYPE_GZIP = COMPRESSION_TYPE_GZIP = 1
 
 compress = (ctype, data) ->
   unless ctype?
@@ -188,6 +188,9 @@ exports.Dispatch = class Dispatch extends Packetizer
         out.cancel = () => @cancel seqid
 
       await (@_invocations[seqid] = defer(error,result) )
+
+      if ctype? and not error
+        result = uncompress ctype, result
 
       debug_msg.response(error, result).call() if debug_msg
 


### PR DESCRIPTION
This change uncompresses results from a compressed `invoke`.

Tests were originally passing because `COMPRESSION_TYPE_GZIP` was not being exported, so all tests that used `invoke_compressed` called it with a null `ctype`, meaning there wasn't actually any compression going on.