### PR TITLE
Add necessary gzip header for compress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.23 (2020-03-31)
+
+ * fix `compress` not prepending a gzip header to the payload
+
 ## v1.1.22 (2020-03-25)
 
  * Send log level to output hook in logger

--- a/lib/client.js
+++ b/lib/client.js
@@ -27,7 +27,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
             funcname: "Client.invoke"
           });
           _this.transport.invoke(arg, __iced_deferrals.defer({
@@ -63,7 +63,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/client.iced",
             funcname: "Client.invoke_compressed"
           });
           _this.transport.invoke(arg, __iced_deferrals.defer({

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -34,7 +34,9 @@
         return data;
       case COMPRESSION_TYPE_GZIP:
         data = pack(data);
-        data = pako.deflate(data);
+        data = pako.deflate(data, {
+          windowBits: 31
+        });
         return toBuffer(data);
       default:
         throw new Error("Compress: unknown compression type " + ctype);
@@ -257,7 +259,7 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/dispatch.iced",
+                filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/dispatch.iced",
                 funcname: "Dispatch.invoke"
               });
               _this._invocations[seqid] = __iced_deferrals.defer({
@@ -267,7 +269,7 @@
                     return result = arguments[1];
                   };
                 })(),
-                lineno: 189
+                lineno: 191
               });
               __iced_deferrals._fulfill();
             })(function() {

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -141,7 +141,7 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+                filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
                 funcname: "Listener.close"
               });
               _this._net_server.close(__iced_deferrals.defer({
@@ -215,7 +215,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
             funcname: "Listener.listen"
           });
           rv.wait(__iced_deferrals.defer({
@@ -266,7 +266,7 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+                  filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
                   funcname: "Listener.listen_retry"
                 });
                 _this.listen(__iced_deferrals.defer({
@@ -285,7 +285,7 @@
                     (function(__iced_k) {
                       __iced_deferrals = new iced.Deferrals(__iced_k, {
                         parent: ___iced_passed_deferral,
-                        filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
+                        filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/listener.iced",
                         funcname: "Listener.listen_retry"
                       });
                       setTimeout(__iced_deferrals.defer({

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -184,7 +184,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "Transport.connect"
           });
           _this._lock.acquire(__iced_deferrals.defer({
@@ -199,7 +199,7 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                  filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                   funcname: "Transport.connect"
                 });
                 _this._connect_critical_section(__iced_deferrals.defer({
@@ -396,7 +396,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "Transport._connect_critical_section"
           });
           rv.wait(__iced_deferrals.defer({
@@ -443,7 +443,7 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                      filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                       funcname: "Transport._connect_critical_section"
                     });
                     _this.hooks.after_connect(__iced_deferrals.defer({
@@ -526,7 +526,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "RobustTransport._connect_critical_section"
           });
           RobustTransport.__super__._connect_critical_section.call(_this, __iced_deferrals.defer({
@@ -562,7 +562,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "RobustTransport._connect_loop"
           });
           _this._lock.acquire(__iced_deferrals.defer({
@@ -599,7 +599,7 @@
                         (function(__iced_k) {
                           __iced_deferrals = new iced.Deferrals(__iced_k, {
                             parent: ___iced_passed_deferral,
-                            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                             funcname: "RobustTransport._connect_loop"
                           });
                           setTimeout(__iced_deferrals.defer({
@@ -613,7 +613,7 @@
                         (function(__iced_k) {
                           __iced_deferrals = new iced.Deferrals(__iced_k, {
                             parent: ___iced_passed_deferral,
-                            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                             funcname: "RobustTransport._connect_loop"
                           });
                           _this._connect_critical_section(__iced_deferrals.defer({
@@ -631,7 +631,7 @@
                               (function(__iced_k) {
                                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                                   parent: ___iced_passed_deferral,
-                                  filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                                  filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                                   funcname: "RobustTransport._connect_loop"
                                 });
                                 setTimeout(__iced_deferrals.defer({
@@ -698,7 +698,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+            filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
             funcname: "RobustTransport._timed_invoke"
           });
           rv.wait(__iced_deferrals.defer({
@@ -734,7 +734,7 @@
                     (function(__iced_k) {
                       __iced_deferrals = new iced.Deferrals(__iced_k, {
                         parent: ___iced_passed_deferral,
-                        filename: "/Users/joshblum/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
+                        filename: "/Users/marcel/Documents/go/src/github.com/keybase/node-framed-msgpack-rpc/src/transport.iced",
                         funcname: "RobustTransport._timed_invoke"
                       });
                       rv.wait(__iced_deferrals.defer({

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,1 @@
-exports.version = "1.1.22";
+exports.version = "1.1.23";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framed-msgpack-rpc",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "description": "Framed Msgpack RPC for node.js",
   "homepage": "https://github.com/keybase/node-framed-msgpack-rpc",
   "main": "./lib/main",

--- a/src/dispatch.iced
+++ b/src/dispatch.iced
@@ -18,7 +18,9 @@ compress = (ctype, data) ->
       return data
     when COMPRESSION_TYPE_GZIP
       data = pack data
-      data = pako.deflate data
+      # set windowBits to 31 = 15 (the default) + 16 (for gzip header)
+      # https://zlib.net/manual.html#Advanced
+      data = pako.deflate data, {windowBits: 31}
       return toBuffer data
     else
       throw new Error "Compress: unknown compression type #{ctype}"


### PR DESCRIPTION
Pako doesn't add a gzip header when compressing (a regression since switching from zlib). The gzip header is necessary for the golang gzip library to uncompress.